### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vSMR Plugin [![Build status](https://ci.appveyor.com/api/projects/status/0ebifm90mrmmatew?svg=true)](https://ci.appveyor.com/project/pierr3/vsmr)
 
-vSMR is a plugin for EuroScope that simulates the NOVA 9000 A-SMGCS system on VATSIM.
+vSMR is a plugin for EuroScope that simulates the NOVA 9000 A-SMGCS. This branch is taylored for vACC Switzerland to simulate the implementation in Switzerland, known as SAMAX.
 
 Features:
 * Custom aircraft polygons with history trails.
@@ -15,14 +15,7 @@ Find out all you need to know on the wiki: <https://github.com/pierr3/vSMR/wiki>
 
 This is the latest stable release, which has been tested and the one you should use for day to day use.
 
-Download the latest release here: <https://github.com/pierr3/vSMR/releases>
-
-### Nightly build
-
-vSMR now has a nightly build courtersey of Appveyor, available at <https://ci.appveyor.com/api/projects/pierr3/vSMR/artifacts/vSMR-nightly.zip>
-
-The nightly build is always up to date with the latest commit, however it may be very unstable and may crash EuroScope. **Don't forget to add the ICAO_Airlines.txt file to the vSMR dll folder when using this build.**
-
+Download the latest release here: <https://github.com/LB767/vSMR/releases>
 
 ### Thanks
 


### PR DESCRIPTION
Adapted to match the vACC specific release, wiki link to be changed when the differences to the default vSMR are documented